### PR TITLE
Add import of ReactDOM from react-dom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@
  */
 
 import React from "react";
+import ReactDOM from "react-dom"
 import ReactDOMServer from "react-dom/server";
 
 class HelloMessage extends React.Component {


### PR DESCRIPTION
We need to import `ReactDOM` from `react-dom` as it's used for registering the service worker.