### PR TITLE
Change style tag to script tag in footer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ body {
     <div id="app">`;
 
 const footer = `</div>
-<style src="/worker.js"></script>
+<script src="/worker.js"></script>
 </body>
 </html>`;
 


### PR DESCRIPTION
The tag in the footer should be `script` not `style`. This fixes the issue for loading the worker.