### PR TITLE
Fix preview crash

### DIFF
--- a/scripts/open-preview.js
+++ b/scripts/open-preview.js
@@ -22,8 +22,7 @@ async function newWorker(script) {
 readFile("dist/worker.js", "utf8").then(data => {
   newWorker(data).then(id =>
     opn(
-      "https://cloudflareworkers.com/#" + id + ":https://reactjs.org",
-      { app: "chromium" }
+      "https://cloudflareworkers.com/#" + id + ":https://reactjs.org"
     )
   );
 });


### PR DESCRIPTION
Removed app parameter from opn (fixing #2). It's not required parameter and causes crash when set to a browser that user doesn't have installed. By leaving this out opn will open the default browser.